### PR TITLE
Raise File.Error if .sql file could not be read

### DIFF
--- a/lib/ayesql.ex
+++ b/lib/ayesql.ex
@@ -356,8 +356,8 @@ defmodule AyeSQL do
   ```
   """
   defmacro defqueries(file) do
-    with {:ok, contents}  <- File.read(file),
-         {:ok, tokens, _} <- :queries_lexer.tokenize(contents),
+    contents = File.read!(file)
+    with {:ok, tokens, _} <- :queries_lexer.tokenize(contents),
          {:ok, ast}       <- :queries_parser.parse(tokens) do
       functions =
         ast

--- a/test/ayesql_test.exs
+++ b/test/ayesql_test.exs
@@ -188,5 +188,15 @@ defmodule AyeSQLTest do
       }
       assert {:ok, {^stmt, ^args}} = Queries.get_avg_ram(params)
     end
+
+    test "throws exception if .sql file not found" do
+      assert_raise File.Error, fn ->
+        defmodule Queries do
+          use AyeSQL
+
+          defqueries("no-existing-file.sql")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Functions would silently not be generated if the .sql could not be read (e.g was misspelled). This avoids that by raising a File.Error at compile time.

Fairly new to Elixir so not entirely sure how to test compile time behaviour. Is that even possible?