### PR TITLE
Added support for Windows new line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.3
+
+### Bug fix
+
+  * Added support for Windows new line.
+
 ## v0.5.2
 
 ### Enhancements

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Ayesql.MixProject do
   use Mix.Project
 
-  @version "0.5.2"
+  @version "0.5.3"
   @root "https://github.com/alexdesousa/ayesql"
 
   def project do

--- a/src/queries_lexer.xrl
+++ b/src/queries_lexer.xrl
@@ -36,16 +36,14 @@ tokenize(Binary) ->
 new_comment(TokenLine, "-- name:" ++ TokenChars) ->
   Value = string:trim(TokenChars),
   {token, {name, TokenLine, list_to_atom(Value)}};
-new_comment(TokenLine, "\n-- name:" ++ TokenChars) ->
-  Value = string:trim(TokenChars),
-  {token, {name, TokenLine, list_to_atom(Value)}};
-new_comment(TokenLine, "\n-- docs:" ++ TokenChars) ->
+new_comment(TokenLine, "-- docs:" ++ TokenChars) ->
   Value = string:trim(TokenChars),
   {token, {docs, TokenLine, list_to_binary(Value)}};
 new_comment(_, "--" ++ _) ->
   skip_token;
-new_comment(TokenLine, "\n" ++ TokenChars) ->
-  new_comment(TokenLine, TokenChars).
+new_comment(TokenLine, TokenChars0) ->
+  TokenChars1 = string:trim(TokenChars0),
+  new_comment(TokenLine, TokenChars1).
 
 new_param(TokenLine, [$: | Name]) ->
   Key = list_to_atom(Name),

--- a/test/ayesql/queries_lexer_test.exs
+++ b/test/ayesql/queries_lexer_test.exs
@@ -1,9 +1,19 @@
 defmodule AyeSQL.QueriesLexerTest do
   use ExUnit.Case, async: true
 
-  test "ignores comment" do
+  test "ignores comment at the beginning of the file" do
     comment = "-- Some comment"
     assert {:ok, [], _} = :queries_lexer.tokenize(comment)
+  end
+
+  test "ignores comment with Unix new line char" do
+    comment = "\n-- Some comment"
+    assert {:ok, [{:fragment, 1, " "}], _} = :queries_lexer.tokenize(comment)
+  end
+
+  test "ignores comment with Windows new line char" do
+    comment = "\r\n-- Some comment"
+    assert {:ok, [{:fragment, 1, " "}], _} = :queries_lexer.tokenize(comment)
   end
 
   test "detects name at the beginning of the file" do
@@ -11,13 +21,23 @@ defmodule AyeSQL.QueriesLexerTest do
     assert {:ok, [{:name, _, :some_name}], _} = :queries_lexer.tokenize(name)
   end
 
-  test "detects name" do
+  test "detects name with Unix new line char" do
     name = "\n-- name: some_name"
     assert {:ok, [{:name, _, :some_name}], _} = :queries_lexer.tokenize(name)
   end
 
-  test "detects docs" do
+  test "detects docs with Unix new line char" do
     docs = "\n-- docs: Some docs"
+    assert {:ok, [{:docs, _, "Some docs"}], _} = :queries_lexer.tokenize(docs)
+  end
+
+  test "detects name with Windows new line char" do
+    name = "\r\n-- name: some_name"
+    assert {:ok, [{:name, _, :some_name}], _} = :queries_lexer.tokenize(name)
+  end
+
+  test "detects docs with Windows new line char" do
+    docs = "\r\n-- docs: Some docs"
     assert {:ok, [{:docs, _, "Some docs"}], _} = :queries_lexer.tokenize(docs)
   end
 


### PR DESCRIPTION
This PR fixes the bug where Windows new lines made lexer fail with a missing function clause e.g:

```elixir
'\r\n--name: some_query'
```

Now it correctly adds ignores the new line.