### PR TITLE
Query stream support

### DIFF
--- a/lib/ayesql/runner.ex
+++ b/lib/ayesql/runner.ex
@@ -8,7 +8,7 @@ defmodule AyeSQL.Runner do
   Callback to initialize the runner.
   """
   @callback run(query :: Query.t(), options :: keyword()) ::
-              :ok | {:ok, term()} | {:error, term()}
+              {:ok, term()} | {:error, term()}
 
   @doc """
   Uses the `AyeSQL.Runner` behaviour.

--- a/lib/ayesql/runner.ex
+++ b/lib/ayesql/runner.ex
@@ -8,7 +8,7 @@ defmodule AyeSQL.Runner do
   Callback to initialize the runner.
   """
   @callback run(query :: Query.t(), options :: keyword()) ::
-              {:ok, term()} | {:error, term()}
+              :ok | {:ok, term()} | {:error, term()}
 
   @doc """
   Uses the `AyeSQL.Runner` behaviour.
@@ -41,5 +41,14 @@ defmodule AyeSQL.Runner do
 
   def handle_result(result) do
     {:ok, result}
+  end
+
+  @doc false
+  @spec handle_result_stream(Enumerable.t()) :: Enumerable.t()
+  def handle_result_stream(stream) do
+    Stream.flat_map(stream, fn batch ->
+      {:ok, result} = handle_result(batch)
+      result
+    end)
   end
 end

--- a/lib/ayesql/runner/ecto.ex
+++ b/lib/ayesql/runner/ecto.ex
@@ -12,19 +12,35 @@ if Code.ensure_loaded?(Ecto.Adapters.SQL) do
       defqueries("query/my_queries.sql")
     end
     ```
+
+    Queries can be run in streaming mode with the `stream_fun` / `stream_timeout` option:
+
+    ``elixir
+    iex> MyQueries.get_user([id: id], run?: true, stream_fun: &IO.inspect/1)
+    :ok
+    ```
+
+    The `stream_fun` function is called for each row in the stream, the whole
+    execution happens in a transaction (ref. `Ecto.Repo.stream/4` docs).
+    `stream_timeout` option can be used to control the underlying ecto
+    transation `timeout` option.
     """
     use AyeSQL.Runner
 
     alias AyeSQL.Query
     alias AyeSQL.Runner
+    alias Ecto.Adapter
     alias Ecto.Adapters.SQL
 
     @impl true
     def run(%Query{statement: stmt, arguments: args}, options) do
       repo = get_repo(options)
+      stream? = Keyword.has_key?(options, :stream_fun)
 
-      with {:ok, result} <- SQL.query(repo, stmt, args) do
-        Runner.handle_result(result)
+      if stream? do
+        stream(repo, stmt, args, options[:stream_fun], options[:stream_timeout])
+      else
+        query(repo, stmt, args)
       end
     end
 
@@ -41,6 +57,37 @@ if Code.ensure_loaded?(Ecto.Adapters.SQL) do
       else
         raise ArgumentError, "Invalid value for #{inspect(repo: repo)}"
       end
+    end
+
+    @spec query(module(), Query.statement(), Query.arguments()) ::
+            {:ok, [map()]}
+    defp query(repo, stmt, args) do
+      with {:ok, result} <- SQL.query(repo, stmt, args) do
+        Runner.handle_result(result)
+      end
+    end
+
+    @spec stream(
+            module(),
+            Query.statement(),
+            Query.arguments(),
+            (map() -> any()),
+            nil | timeout()
+          ) :: {:ok, :ok}
+    defp stream(repo, stmt, args, stream_fun, stream_timeout) do
+      transaction_options =
+        if stream_timeout, do: [timeout: stream_timeout], else: []
+
+      adapter_meta = Adapter.lookup_meta(repo)
+
+      SQL.transaction(adapter_meta, transaction_options, fn ->
+        SQL.stream(repo, stmt, args)
+        |> Runner.handle_result_stream()
+        |> Stream.each(stream_fun)
+        |> Stream.run()
+      end)
+
+      {:ok, :ok}
     end
   end
 end

--- a/lib/ayesql/runner/ecto.ex
+++ b/lib/ayesql/runner/ecto.ex
@@ -75,10 +75,10 @@ if Code.ensure_loaded?(Ecto.Adapters.SQL) do
             nil | timeout()
           ) :: {:ok, :ok}
     defp stream(repo, stmt, args, stream_fun, stream_timeout) do
+      adapter_meta = Adapter.lookup_meta(repo)
+
       transaction_options =
         if stream_timeout, do: [timeout: stream_timeout], else: []
-
-      adapter_meta = Adapter.lookup_meta(repo)
 
       SQL.transaction(adapter_meta, transaction_options, fn ->
         SQL.stream(repo, stmt, args)

--- a/lib/ayesql/runner/postgrex.ex
+++ b/lib/ayesql/runner/postgrex.ex
@@ -54,7 +54,7 @@ if Code.ensure_loaded?(Postgrex) do
           transaction_options
         )
 
-        :ok
+        {:ok, nil}
       else
         with {:ok, result} <- Postgrex.query(conn, stmt, args) do
           Runner.handle_result(result)


### PR DESCRIPTION
Hi, @alexdesousa,
I've played a bit to extend the query execution mode to support the postgrex / ecto stream mode.
Hope it make sense for the library and its design.

I thought about how to introduce it in the current interface to the queries, being clean an backward compatible.

I think a new options could be used:

```elixir
# Current query behaviour, result collected in memory and returned as a list to the caller
MyQueries.get_user([id: id], run?: true)

# Stream mode, the `stream_fun` function is called for each row in the stream,
# the whole execution happens in a transaction (ref Postgrex.stream and Ecto.Repo.stream)
MyQueries.get_user([id: id], run?: true, stream_fun: &IO.inspect/1)
```

Feel free to change / refactor / adjust if you think this feature can be included in the library.

Thank you