### PR TITLE
allow_to_return_raw_or_keyword_list

### DIFF
--- a/lib/ayesql.ex
+++ b/lib/ayesql.ex
@@ -136,7 +136,7 @@ defmodule AyeSQL do
   possible values are:
   - an empty map: `Map.new()` or `%{}`
   - an empty list: Keyword.new()` or `[]`
-  - A struct
+  - a struct
   - `:raw` - will return unmodified Postgrex result
 
   ```elixir

--- a/lib/ayesql.ex
+++ b/lib/ayesql.ex
@@ -131,6 +131,38 @@ defmodule AyeSQL do
     ]
   }
   ```
+  AyeSQL also allows you to choose the type of returned data structures.
+  Instead of the default map you can also pass an into option to your query
+  possible values are:
+  - Map or %{}
+  - Keyword or []
+  - A struct
+  - :raw - will return unmodified Postgrex result
+
+  ```elixir
+  iex> Queries.get_avg_clicks(params, into: Keyword)
+  {:ok,
+    [
+      [day: ..., count: ...],
+      [day: ..., count: ...],
+      [day: ..., count: ...],
+      ...
+    ]
+  }
+  ```
+
+  ```elixir
+  iex> defmodule AvgClicks do defstruct [:day, :count] end
+  iex> Queries.get_avg_clicks(params, into: AvgClicks)
+  {:ok,
+    [
+      %AvgClicks{day: ..., count: ...},
+      %AvgClicks{day: ..., count: ...},
+      %AvgClicks{day: ..., count: ...},
+      ...
+    ]
+  }
+  ```
   """
   alias AyeSQL.Compiler
   alias AyeSQL.Query

--- a/lib/ayesql.ex
+++ b/lib/ayesql.ex
@@ -132,15 +132,15 @@ defmodule AyeSQL do
   }
   ```
   AyeSQL also allows you to choose the type of returned data structures.
-  Instead of the default map you can also pass an into option to your query
+  Instead of the default map you can also pass an `into` option to your query
   possible values are:
-  - Map or %{}
-  - Keyword or []
+  - an empty map: `Map.new()` or `%{}`
+  - an empty list: Keyword.new()` or `[]`
   - A struct
-  - :raw - will return unmodified Postgrex result
+  - `:raw` - will return unmodified Postgrex result
 
   ```elixir
-  iex> Queries.get_avg_clicks(params, into: Keyword)
+  iex> Queries.get_avg_clicks(params, into: [])
   {:ok,
     [
       [day: ..., count: ...],

--- a/lib/ayesql/runner.ex
+++ b/lib/ayesql/runner.ex
@@ -21,31 +21,33 @@ defmodule AyeSQL.Runner do
 
   # Handles the result.
   @doc false
-  @spec handle_result(map()) :: [map() | struct()]
-  @spec handle_result(map(), keyword()) :: [map() | struct()]
+  @spec handle_result(map()) :: [map() | struct() | keyword()]
+  @spec handle_result(map(), keyword()) :: [map() | struct() | keyword()]
   def handle_result(result, options \\ [])
+
+  def handle_result(data, options) when is_list(options) do
+    handle_result(data, Map.new(options))
+  end
+
+  def handle_result(raw_data, %{into: :raw}) do
+    raw_data
+  end
 
   def handle_result(%{columns: nil}, _options) do
     []
   end
 
-  def handle_result(%{columns: columns, rows: rows} = raw_data, options) do
-    if options[:into] == :raw do
-      raw_data
-    else
-      atom_columns = Stream.map(columns, &String.to_atom/1)
+  def handle_result(%{columns: columns, rows: rows}, options) do
+    atom_columns = Stream.map(columns, &String.to_atom/1)
 
-      rows
-      |> Stream.map(&Stream.zip(atom_columns, &1))
-      |> Enum.map(fn row ->
-        case options[:into] do
-          nil -> Enum.into(row, %{})
-          Map -> Enum.into(row, %{})
-          Keyword -> Enum.into(row, [])
-          enum when enum == [] or enum == %{} -> Enum.into(row, enum)
-          struct -> struct(struct, row)
-        end
-      end)
-    end
+    rows
+    |> Stream.map(&Stream.zip(atom_columns, &1))
+    |> Enum.map(fn row ->
+      case options[:into] do
+        struct when is_struct(struct) -> struct(struct, row)
+        [] -> Enum.into(row, [])
+        _ -> Enum.into(row, %{})
+      end
+    end)
   end
 end

--- a/lib/ayesql/runner.ex
+++ b/lib/ayesql/runner.ex
@@ -42,6 +42,7 @@ defmodule AyeSQL.Runner do
           nil -> Enum.into(row, %{})
           Map -> Enum.into(row, %{})
           Keyword -> Enum.into(row, [])
+          enum when enum == [] or enum == %{} -> Enum.into(row, enum)
           struct -> struct(struct, row)
         end
       end)

--- a/test/ayesql/runner_test.exs
+++ b/test/ayesql/runner_test.exs
@@ -28,7 +28,6 @@ defmodule AyeSQL.RunnerTest do
         %{username: "alice", email: "alice@example.com"}
       ]
 
-      assert ^expected = Runner.handle_result(data, into: Map)
       assert ^expected = Runner.handle_result(data, into: %{})
     end
 
@@ -46,7 +45,6 @@ defmodule AyeSQL.RunnerTest do
         [username: "alice", email: "alice@example.com"]
       ]
 
-      assert expected == Runner.handle_result(data, into: Keyword)
       assert expected == Runner.handle_result(data, into: [])
     end
 
@@ -64,7 +62,7 @@ defmodule AyeSQL.RunnerTest do
         %User{username: "alice", email: "alice@example.com"}
       ]
 
-      assert expected == Runner.handle_result(data, into: User)
+      assert expected == Runner.handle_result(data, into: %User{})
     end
 
     test "when rows are not empty, returns a raw result with columns and rows" do

--- a/test/ayesql/runner_test.exs
+++ b/test/ayesql/runner_test.exs
@@ -28,24 +28,8 @@ defmodule AyeSQL.RunnerTest do
         %{username: "alice", email: "alice@example.com"}
       ]
 
-      assert ^expected = Runner.handle_result(data)
-    end
-
-    test "when rows are not empty, returns a list of map rows" do
-      data = %{
-        columns: ["username", "email"],
-        rows: [
-          ["bob", "bob@example.com"],
-          ["alice", "alice@example.com"]
-        ]
-      }
-
-      expected = [
-        %{username: "bob", email: "bob@example.com"},
-        %{username: "alice", email: "alice@example.com"}
-      ]
-
       assert ^expected = Runner.handle_result(data, into: Map)
+      assert ^expected = Runner.handle_result(data, into: %{})
     end
 
     test "when rows are not empty, returns a list of keyword rows" do
@@ -63,6 +47,7 @@ defmodule AyeSQL.RunnerTest do
       ]
 
       assert expected == Runner.handle_result(data, into: Keyword)
+      assert expected == Runner.handle_result(data, into: [])
     end
 
     test "when rows are not empty, returns a list of structs rows" do

--- a/test/ayesql/runner_test.exs
+++ b/test/ayesql/runner_test.exs
@@ -3,6 +3,10 @@ defmodule AyeSQL.RunnerTest do
 
   alias AyeSQL.Runner
 
+  defmodule User do
+    defstruct [:username, :email]
+  end
+
   describe "handle_result/1" do
     test "when columns are nil, returns empty list" do
       data = %{columns: nil}
@@ -10,7 +14,7 @@ defmodule AyeSQL.RunnerTest do
       assert [] = Runner.handle_result(data)
     end
 
-    test "when rows are not empty, returns a list of rows with columns" do
+    test "when rows are not empty, returns a list of map rows by default" do
       data = %{
         columns: ["username", "email"],
         rows: [
@@ -25,6 +29,69 @@ defmodule AyeSQL.RunnerTest do
       ]
 
       assert ^expected = Runner.handle_result(data)
+    end
+
+    test "when rows are not empty, returns a list of map rows" do
+      data = %{
+        columns: ["username", "email"],
+        rows: [
+          ["bob", "bob@example.com"],
+          ["alice", "alice@example.com"]
+        ]
+      }
+
+      expected = [
+        %{username: "bob", email: "bob@example.com"},
+        %{username: "alice", email: "alice@example.com"}
+      ]
+
+      assert ^expected = Runner.handle_result(data, into: Map)
+    end
+
+    test "when rows are not empty, returns a list of keyword rows" do
+      data = %{
+        columns: ["username", "email"],
+        rows: [
+          ["bob", "bob@example.com"],
+          ["alice", "alice@example.com"]
+        ]
+      }
+
+      expected = [
+        [username: "bob", email: "bob@example.com"],
+        [username: "alice", email: "alice@example.com"]
+      ]
+
+      assert expected == Runner.handle_result(data, into: Keyword)
+    end
+
+    test "when rows are not empty, returns a list of structs rows" do
+      data = %{
+        columns: ["username", "email"],
+        rows: [
+          ["bob", "bob@example.com"],
+          ["alice", "alice@example.com"]
+        ]
+      }
+
+      expected = [
+        %User{username: "bob", email: "bob@example.com"},
+        %User{username: "alice", email: "alice@example.com"}
+      ]
+
+      assert expected == Runner.handle_result(data, into: User)
+    end
+
+    test "when rows are not empty, returns a raw result with columns and rows" do
+      data = %{
+        columns: ["username", "email"],
+        rows: [
+          ["bob", "bob@example.com"],
+          ["alice", "alice@example.com"]
+        ]
+      }
+
+      assert data == Runner.handle_result(data, into: :raw)
     end
   end
 end

--- a/test/support/script.sql
+++ b/test/support/script.sql
@@ -1,0 +1,5 @@
+-- Runs multiple sql statements
+-- name: set_schema
+-- type: script
+CREATE SCHEMA schema1;
+CREATE SCHEMA schema2;

--- a/test/support/script.sql
+++ b/test/support/script.sql
@@ -1,5 +1,0 @@
--- Runs multiple sql statements
--- name: set_schema
--- type: script
-CREATE SCHEMA schema1;
-CREATE SCHEMA schema2;


### PR DESCRIPTION
This allows to get the raw data data returned by postgrex for use with for example table_rex.
It also allows to convert to keyword list which is sorted comparing to maps.
Default `into` param can be passed to use function.
