### PR TITLE
Add fragment support

### DIFF
--- a/lib/ayesql/lexer.ex
+++ b/lib/ayesql/lexer.ex
@@ -34,6 +34,7 @@ defmodule AyeSQL.Lexer do
   @type token_name ::
           :"$name"
           | :"$docs"
+          | :"$query_fragment_metadata"
           | :"$fragment"
           | :"$named_param"
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AyeSQL.MixProject do
   use Mix.Project
 
-  @version "1.1.3"
+  @version "1.1.4"
   @name "AyeSQL"
   @description "Library for using raw SQL"
   @app :ayesql

--- a/src/ayesql_lexer.xrl
+++ b/src/ayesql_lexer.xrl
@@ -9,8 +9,8 @@ NewLine    = (\n|\r)+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Comments and special directives
 
-FunName    = {NewLine}*(\-\-)\sname\:\s[^\n\r]+
-FunDocs    = {NewLine}*(\-\-)\sdocs\:\s[^\n\r]+
+FunName    = {NewLine}*{WhiteSpace}*(\-\-)\sname\:\s[^\n\r]+
+FunDocs    = {NewLine}*{WhiteSpace}*(\-\-)\sdocs\:\s[^\n\r]+
 Comment    = (\-\-)[^\n\r]+
 
 Atom       = [a-z_][0-9a-zA-Z_]*

--- a/src/ayesql_lexer.xrl
+++ b/src/ayesql_lexer.xrl
@@ -11,6 +11,7 @@ NewLine    = (\n|\r)+
 
 FunName    = {NewLine}*{WhiteSpace}*(\-\-)\sname\:\s[^\n\r]+
 FunDocs    = {NewLine}*{WhiteSpace}*(\-\-)\sdocs\:\s[^\n\r]+
+FunFrag    = {NewLine}*{WhiteSpace}*(\-\-)\sfragment\:\s[^\n\r]+
 Comment    = (\-\-)[^\n\r]+
 
 Atom       = [a-z_][0-9a-zA-Z_]*
@@ -26,7 +27,7 @@ Rules.
 
 {FunName}                           : new_comment(TokenLine, TokenLen, TokenChars).
 {FunDocs}                           : new_comment(TokenLine, TokenLen, TokenChars).
-
+{FunFrag}                           : new_comment(TokenLine, TokenLen, TokenChars).
 {NamedParam}                        : new_param(TokenLine, TokenLen, TokenChars).
 ({Comment}?|({String}|{Fragment})+) : new_fragment(TokenLine, TokenLen, TokenChars).
 
@@ -67,6 +68,9 @@ new_comment(TokenLine, TokenLen, "-- name: " ++ Value = TokenChars) ->
 new_comment(TokenLine, TokenLen, "-- docs: " ++ Value = TokenChars) ->
   Documentation = string:trim(Value),
   new_token("docs", Documentation, TokenChars, TokenLine, TokenLen);
+new_comment(TokenLine, TokenLen, "-- fragment: " ++ Value = TokenChars) ->
+  Fragment = string:trim(Value),
+  new_token("query_fragment_metadata", Fragment, TokenChars, TokenLine, TokenLen);
 new_comment(_, _, "--" ++ _) ->
   skip_token;
 new_comment(TokenLine, TokenLen, TokenChars) ->

--- a/src/ayesql_parser.yrl
+++ b/src/ayesql_parser.yrl
@@ -1,7 +1,6 @@
 Nonterminals queries named_queries named_query fragments.
-Terminals '$name' '$docs' '$fragment' '$named_param'.
+Terminals '$name' '$docs' '$fragment' '$query_fragment_metadata' '$named_param'.
 Rootsymbol queries.
-
 
 queries -> fragments     : [ {nil, nil, join_fragments('$1', [])} ].
 queries -> named_queries : '$1'.
@@ -9,8 +8,9 @@ queries -> named_queries : '$1'.
 named_queries -> named_query               : [ '$1' ].
 named_queries -> named_query named_queries : [ '$1' | '$2' ].
 
-named_query -> '$name' fragments         : {extract_value('$1'), nil, join_fragments('$2', [])}.
-named_query -> '$name' '$docs' fragments : {extract_value('$1'), extract_value('$2'), join_fragments('$3', [])}.
+named_query -> '$name' fragments                                    : {extract_value('$1'), nil, join_fragments('$2', []), false}.
+named_query -> '$name' '$docs' fragments                            : {extract_value('$1'), extract_value('$2'), join_fragments('$3', []), false}.
+named_query -> '$name' '$docs' '$query_fragment_metadata' fragments : {extract_value('$1'), extract_value('$2'), join_fragments('$4', []), true}.
 
 fragments -> '$fragment'              : [ extract_value('$1') ].
 fragments -> '$named_param'           : [ extract_value('$1') ].
@@ -27,6 +27,8 @@ extract_value({'$docs', _, {Value, _, _}}) ->
   Value;
 extract_value({'$fragment', _, {Value, _, _}}) ->
   Value;
+extract_value({'$query_fragment_metadata', _, {Value, _, _}}) ->
+    Value;
 extract_value({'$named_param', _, {Value, _, _}}) ->
   binary_to_atom(Value).
 

--- a/test/ayesql/compiler_test.exs
+++ b/test/ayesql/compiler_test.exs
@@ -9,6 +9,31 @@ defmodule AyeSQL.CompilerTest do
         Compiler.compile_queries("SELECT * FROM table")
       end
     end
+
+    test "should succeed when docs are provided after name" do
+      contents = """
+      -- name: function_name
+      -- docs: Documentation
+      Query
+      """
+
+      [tuple | _rest] = Compiler.compile_queries(contents)
+      assert is_tuple(tuple)
+      assert elem(tuple, 0) == :def
+    end
+
+    test "should succeed when fragment: true is specified" do
+      contents = """
+      -- name: function_name
+      -- docs: Documentation
+      -- fragment: true
+      Query
+      """
+
+      [tuple | _rest] = Compiler.compile_queries(contents)
+      assert is_tuple(tuple)
+      assert elem(tuple, 0) == :def
+    end
   end
 
   describe "eval_query/2" do

--- a/test/ayesql/lexer_test.exs
+++ b/test/ayesql/lexer_test.exs
@@ -23,6 +23,16 @@ defmodule AyeSQL.LexerTest do
     end
   end
 
+  describe "fragment boolean" do
+    test "gets fragment metadata" do
+      target = "-- fragment: true"
+
+      assert [
+               {:"$query_fragment_metadata", 1, {"true", ^target, {1, 1}}}
+             ] = Lexer.tokenize(target)
+    end
+  end
+
   describe "comments" do
     test "ignores comments" do
       target = """

--- a/test/ayesql_test.exs
+++ b/test/ayesql_test.exs
@@ -324,4 +324,17 @@ defmodule AyeSQLTest do
       assert {:ok, {_, [], [repo: MyRepo]}} = WithRunner.get_hostnames([])
     end
   end
+
+  test "correctly identifies fragment functions" do
+    defmodule FragmentTest do
+      use AyeSQL, runner: TestRunner, repo: MyRepo
+
+      defqueries("support/fragments.sql")
+    end
+
+    # Add debug output
+    IO.puts("Module attributes: #{inspect(FragmentTest.__info__(:attributes))}")
+
+    assert FragmentTest.fragment_functions() == [:user_fields]
+  end
 end

--- a/test/support/fragments.sql
+++ b/test/support/fragments.sql
@@ -1,0 +1,5 @@
+-- Simple fragment query
+-- name: user_fields
+-- docs: Simple query
+-- fragment: true
+WHERE user_fields = :user_fields


### PR DESCRIPTION
I'm a little conflicted about how clean a change this is, but, it does what I wanted and maybe it's a useful part of deciding if the feature is useful to the library in general (or if there's some more general metadata or other changes to bias towards instead if other usecases for function metadata make sense, since this feels a little awkward and tightly coupled to pass just one bit of information through for each function)

I thought I had a (maybe marginally cleaner?) different way to define the final `fragment_functions` callback using a module attribute with `accumulate: true` but for some reason that wasn't working, so landed on this direct definition.

At the moment it incorporates the commit from my other PR #40 since they both touch the lexer, that's obviously a smaller change though and not tightly coupled.

In any case, attempts to address #41 